### PR TITLE
Fixed Dockerfile instantclient script permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ ENV OCI_LIB_DIR=/opt/oracle/instantclient
 ENV OCI_INCLUDE_DIR=/opt/oracle/instantclient/sdk/include
 
 # INSTALL INSTANTCLIENT AND DEPENDENCIES
-RUN ./install-instantclient.sh \
-    && pip install -r requirements.txt
+RUN ["/bin/bash",  "./install-instantclient.sh"]
+
+RUN pip install -r requirements.txt
 
 EXPOSE 5000
 


### PR DESCRIPTION
Dockerfile was failing on the build @ the oracle client bash script due to `insufficient permissions`.

Explicitly specifying the bash binary seemed to fix the issue. Basically mimicked the format in the inspired repo https://github.com/valudio/docker-python-flask-oracle/blob/master/Dockerfile

